### PR TITLE
Update MetaBrainz.Build.Sdk to 1.0.1

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2021 Tim Van Holder
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/MetaBrainz.Common.Json/Converters/AnyObjectReader.cs
+++ b/MetaBrainz.Common.Json/Converters/AnyObjectReader.cs
@@ -97,7 +97,7 @@ namespace MetaBrainz.Common.Json.Converters {
               dec = decVal;
             else
               dec = null;
-#if NETFRAMEWORK // No IsFinite()
+#if NETFRAMEWORK || NETSTANDARD2_0 // No IsFinite()
             if (reader.TryGetDouble(out var floatVal) && !double.IsInfinity(floatVal) && !double.IsNaN(floatVal))
               fp = floatVal;
             else

--- a/MetaBrainz.Common.Json/JsonUtils.cs
+++ b/MetaBrainz.Common.Json/JsonUtils.cs
@@ -21,7 +21,7 @@ namespace MetaBrainz.Common.Json {
     #region General Utilities
 
     private static string DecodeUtf8(ReadOnlySpan<byte> bytes) {
-#if NETFRAMEWORK // No Span-based API
+#if NETFRAMEWORK || NETSTANDARD2_0 // No Span-based API
       return Encoding.UTF8.GetString(bytes.ToArray());
 #else
       return Encoding.UTF8.GetString(bytes);

--- a/README.md
+++ b/README.md
@@ -4,11 +4,35 @@ JSON-related helper classes, for use by the other `MetaBrainz.*` packages.
 
 ## Release Notes
 
+### v4.0.1 (not yet released)
+
+- Changed the license to MIT (from MS-PL)
+- Changed target frameworks to `netstandard2.0`, `netstandard2.1`, and `net472`
+
+#### Dependency Updates
+
+- MetaBrainz.Build.Sdk → 1.0.1
+- JetBrainz.Annotations → 2020.1.0
+- System.Text.Json → 5.0.2
+
+### v4.0.0 (2020-12-23)
+
+- Switch to a NuGet SDK package (MetaBrainz.Build.Sdk) instead of a Git submodule
+
+#### API Additions
+
+- Two non-null variations of `Utf8JsonReader.GetString()` were added:
+  - `GetStringValue()` for `String` nodes
+  - `GetPropertyName()` for `PropertyName` nodes
+
+#### Dependency Updates
+
+- System.Text.Json → 5.0.0
+
 ### v3.0.1 (2020-05-10)
 
-This makes the output of `Prettify()` pretty again. Indented writing was previously only enabled in debug builds,
-so essentially never when consuming the NuGet package.
-
+- This makes the output of `Prettify()` pretty again
+  - Indented writing was previously only enabled in debug builds, so essentially never when consuming the NuGet package
 
 ### v3.0.0 (2020-04-25)
 
@@ -22,7 +46,6 @@ so essentially never when consuming the NuGet package.
 - JsonBasedObject: this once again has a regular `Dictionary` as `UnhandledProperties`
   - this allows implementation types to modify the contents after the initial object creation
   - *this is, unfortunately, a breaking change*
-
 
 ### v2.0.0 (2020-04-24)
 
@@ -74,11 +97,9 @@ so essentially never when consuming the NuGet package.
 - `InterfaceConverter` and `ReadOnlyListOfInterfaceConverter` have been removed
   - the MetaBrainz libraries are switching to custom converters for everything, removing the need for these
 
-
 ### v1.1.1 (2020-04-16)
 
 This version fixes a build issue causing the XML documentation to be missing from the NuGet package.
-
 
 ### v1.1.0 (2020-04-15)
 
@@ -112,14 +133,13 @@ This version fixes a build issue causing the XML documentation to be missing fro
 
 #### Other Changes
 
-- tweaks and updates to the build system
-- marked more types as `[PublicAPI]` (dev-time change only)
+- Tweaks and updates to the build system
+- Marked more types as `[PublicAPI]` (dev-time change only)
 
 #### Dependency Updates
 
 - JetBrainz.Annotations → 2020.1.0
 - System.Text.Json → 4.7.1
-
 
 ### v1.0.0 (2020-03-20)
 

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "msbuild-sdks": {
-    "MetaBrainz.Build.Sdk" : "1.0.0"
+    "MetaBrainz.Build.Sdk" : "1.0.1"
   }
 }


### PR DESCRIPTION
This includes a switch to the MIT license, as well as code tweaks for `netstandard2.0` support.
Updated the release notes as well.