### PR TITLE
Update MetaBrainz.Build.Sdk to version 2.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   <!-- Package Versions -->
   <ItemGroup>
     <PackageVersion Include="JetBrains.Annotations" Version="2021.3.0" />
-    <PackageVersion Include="System.Text.Json" Version="5.0.2" />
+    <PackageVersion Include="System.Text.Json" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/MetaBrainz.Common.Json.sln
+++ b/MetaBrainz.Common.Json.sln
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Support Files", "Support Fi
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		appveyor.yml = appveyor.yml
+		build-package.ps1 = build-package.ps1
 		Directory.Packages.props = Directory.Packages.props
 		global.json = global.json
 		LICENSE.md = LICENSE.md

--- a/MetaBrainz.Common.Json/JsonUtils.cs
+++ b/MetaBrainz.Common.Json/JsonUtils.cs
@@ -83,7 +83,7 @@ namespace MetaBrainz.Common.Json {
     #region Options
 
     private static readonly JsonSerializerOptions PrettifyOptions = new() {
-      IgnoreNullValues = false,
+      DefaultIgnoreCondition = JsonIgnoreCondition.Never,
       WriteIndented = true,
     };
 
@@ -95,7 +95,7 @@ namespace MetaBrainz.Common.Json {
     /// <returns>JSON serializer options for reading (deserialization).</returns>
     public static JsonSerializerOptions CreateReaderOptions() => new() {
       AllowTrailingCommas = false,
-      IgnoreNullValues = false,
+      DefaultIgnoreCondition = JsonIgnoreCondition.Never,
       PropertyNameCaseInsensitive = false,
     };
 
@@ -126,7 +126,7 @@ namespace MetaBrainz.Common.Json {
     /// <summary>Creates JSON serializer options for writing (serialization).</summary>
     /// <returns>JSON serializer options for writing (serialization).</returns>
     public static JsonSerializerOptions CreateWriterOptions() => new() {
-      IgnoreNullValues = false,
+      DefaultIgnoreCondition = JsonIgnoreCondition.Never,
       IgnoreReadOnlyProperties = false,
 #if DEBUG
       WriteIndented = true,

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ JSON-related helper classes, for use by the other `MetaBrainz.*` packages.
 
 ### v4.0.2 (not yet released)
 
+- Changed target frameworks to `net6.0`, `netstandard2.1`, `netstandard2.0`, and `net48`
+
+#### Dependency Updates
+
+- MetaBrainz.Build.Sdk → 2.0.0
 - System.Text.Json → 6.0.0
 
 ### v4.0.1 (2021-11-06)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ JSON-related helper classes, for use by the other `MetaBrainz.*` packages.
 
 ### v4.0.2 (not yet released)
 
+- System.Text.Json → 6.0.0
+
 ### v4.0.1 (2021-11-06)
 
 - Changed the license to MIT (from MS-PL)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: 'Build #{build}'
-image: Visual Studio 2019
+image: Visual Studio 2022
 before_build:
 - ps: dotnet restore
 build_script:

--- a/build-package.ps1
+++ b/build-package.ps1
@@ -1,0 +1,25 @@
+#Requires -Version 5.1
+
+[CmdletBinding()]
+param (
+  [string] $Configuration = 'Release'
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (Test-Path -Path output) {
+  Write-Host 'Cleaning up existing build output...'
+  Remove-Item -Recurse output
+}
+
+Write-Host "Running package restore..."
+dotnet restore
+
+Write-Host "Building the solution ($Configuration mode)..."
+dotnet build --nologo --no-restore -c:$Configuration '-p:ContinuousIntegrationBuild=true' '-p:Deterministic=true'
+
+Write-Host "Running tests..."
+dotnet test --nologo --no-build -c:$Configuration
+
+Write-Host "Creating packages..."
+dotnet pack --nologo --no-build -c:$Configuration

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "msbuild-sdks": {
-    "MetaBrainz.Build.Sdk" : "1.0.1"
+    "MetaBrainz.Build.Sdk" : "2.0.0"
   }
 }


### PR DESCRIPTION
This also:
- updates System.Text.Json to 6.0.0
- implies changes to the target frameworks, adding `net6.0` and bumping `net472` up to `net48`