### PR TITLE
Use `MetaBrainz.Common`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
   <!-- Package Versions -->
   <ItemGroup>
     <PackageVersion Include="JetBrains.Annotations" Version="2021.3.0" />
+    <PackageVersion Include="MetaBrainz.Common" Version="1.0.0" />
     <PackageVersion Include="System.Text.Json" Version="6.0.0" />
   </ItemGroup>
 

--- a/MetaBrainz.Common.Json/JsonUtils.cs
+++ b/MetaBrainz.Common.Json/JsonUtils.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
@@ -20,29 +19,19 @@ public static class JsonUtils {
 
   #region General Utilities
 
-  private static string DecodeUtf8(ReadOnlySpan<byte> bytes) {
-#if NETFRAMEWORK || NETSTANDARD2_0 // No Span-based API
-    return Encoding.UTF8.GetString(bytes.ToArray());
-#else
-    return Encoding.UTF8.GetString(bytes);
-#endif
-  }
-
   /// <summary>Deserializes JSON to an object of the specified type, using default options.</summary>
   /// <param name="json">The JSON to deserialize.</param>
   /// <typeparam name="T">The type of object to deserialize.</typeparam>
   /// <returns>A newly deserialized object of type <typeparamref name="T"/>.</returns>
   /// <remarks>The options used match those returned by <see cref="CreateReaderOptions()"/>.</remarks>
-  public static T? Deserialize<T>(string json)
-    => JsonUtils.Deserialize<T>(json, JsonUtils.ReaderOptions);
+  public static T? Deserialize<T>(string json) => JsonUtils.Deserialize<T>(json, JsonUtils.ReaderOptions);
 
   /// <summary>Deserializes JSON to an object of the specified type.</summary>
   /// <param name="json">The JSON to deserialize.</param>
   /// <param name="options">The options to use for deserialization.</param>
   /// <typeparam name="T">The type of object to deserialize.</typeparam>
   /// <returns>A newly deserialized object of type <typeparamref name="T"/>.</returns>
-  public static T? Deserialize<T>(string json, JsonSerializerOptions options)
-    => JsonSerializer.Deserialize<T>(json, options);
+  public static T? Deserialize<T>(string json, JsonSerializerOptions options) => JsonSerializer.Deserialize<T>(json, options);
 
   /// <summary>Deserializes JSON to an object of the specified type, using default options.</summary>
   /// <param name="json">The JSON to deserialize.</param>
@@ -60,9 +49,8 @@ public static class JsonUtils {
   /// <typeparam name="T">The type of object to deserialize.</typeparam>
   /// <returns>A newly deserialized object of type <typeparamref name="T"/>.</returns>
   public static ValueTask<T?> DeserializeAsync<T>(Stream json, JsonSerializerOptions options,
-                                                  CancellationToken cancellationToken = default) {
-    return JsonSerializer.DeserializeAsync<T>(json, options, cancellationToken);
-  }
+                                                  CancellationToken cancellationToken = default)
+    => JsonSerializer.DeserializeAsync<T>(json, options, cancellationToken);
 
   /// <summary>Pretty-prints a JSON string.</summary>
   /// <param name="json">The JSON string to pretty-print.</param>
@@ -343,11 +331,11 @@ public static class JsonUtils {
     var value = "";
     if (reader.HasValueSequence) {
       foreach (var memory in reader.ValueSequence) {
-        value += JsonUtils.DecodeUtf8(memory.Span);
+        value += TextUtils.DecodeUtf8(memory.Span);
       }
     }
     else {
-      value = JsonUtils.DecodeUtf8(reader.ValueSpan);
+      value = TextUtils.DecodeUtf8(reader.ValueSpan);
     }
     return value;
   }

--- a/MetaBrainz.Common.Json/MetaBrainz.Common.Json.csproj
+++ b/MetaBrainz.Common.Json/MetaBrainz.Common.Json.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" IncludeAssets="compile" PrivateAssets="all" />
+    <PackageReference Include="MetaBrainz.Common" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 


### PR DESCRIPTION
Currently this just means the `DecodeUtf8` method is dropped in favour of the one from `TextUtils`.