### PR TITLE
Update the build SDK to version 3.1.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,13 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "dependencies"
+      - "nuget"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+      - "gh-actions"

--- a/.github/github-labels.yml
+++ b/.github/github-labels.yml
@@ -36,6 +36,14 @@
   color: '008672'
   description: "Changes related to unit tests"
 
+# Additional Labels Used by Dependabot
+- name: gh-actions
+  color: '1d0128'
+  description: "Version updates for GitHub actions"
+- name: nuget
+  color: '1d0128'
+  description: "Version updates for NuGet packages"
+
 # Additional Labels for Release Drafter Version Resolution
 - name: bump-major-version
   color: 'cf996b'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,52 @@
+﻿name: Build
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      dotnet-version: 8.0.x
+    strategy:
+      matrix:
+        configuration: ['Debug', 'Release']
+
+    steps:
+    - name: Check out the project
+      uses: actions/checkout@v4
+    - name: Set up .NET ${{env.dotnet-version}}
+      uses: actions/setup-dotnet@v4
+      id: setup
+      with:
+        dotnet-version: ${{env.dotnet-version}}
+      env:
+        NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    - name: Create global.json to force use of .NET SDK ${{steps.setup.outputs.dotnet-version}}
+      run: echo '{"sdk":{"version":"${{steps.setup.outputs.dotnet-version}}"}}' > ./global.json
+    - name: Run build script (${{matrix.configuration}})
+      run: pwsh ./build-package.ps1 -ContinuousIntegration -WithBinLog -Configuration ${{matrix.configuration}}
+    - name: "Artifact: MSBuild Logs"
+      uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: MSBuild Logs (${{matrix.configuration}})
+        path: msbuild.*.binlog
+    - name: "Artifact: NuGet Packages"
+      uses: actions/upload-artifact@v3
+      with:
+        name: NuGet Packages (${{matrix.configuration}})
+        path: "output/package/${{matrix.configuration}}/*.*nupkg"
+    - name: Publish (NuGet - GitHub Packages)
+      if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
+      run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg -s https://nuget.pkg.github.com/zastai/index.json -k ${{secrets.GITHUB_TOKEN}}"
+    - name: Publish (NuGet - nuget.org)
+      if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
+      run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,6 +10,6 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v5.15.0
+      - uses: release-drafter/release-drafter@v5.25.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-labels.yml
+++ b/.github/workflows/update-labels.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Labeler
         if: success()
-        uses: crazy-max/ghaction-github-labeler@v3
+        uses: crazy-max/ghaction-github-labeler@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           yaml-file: .github/github-labels.yml

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,6 @@
   <ItemGroup>
     <PackageVersion Include="JetBrains.Annotations" Version="2021.3.0" />
     <PackageVersion Include="MetaBrainz.Common" Version="1.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2021 Tim Van Holder
+Copyright (c) 2020, 2021, 2022, 2023 Tim Van Holder
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/MetaBrainz.Common.Json.sln
+++ b/MetaBrainz.Common.Json.sln
@@ -6,10 +6,8 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Support Files", "Support Files", "{F997B31A-CF25-4C63-BEB5-172F7E13D9B3}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
-		appveyor.yml = appveyor.yml
 		build-package.ps1 = build-package.ps1
 		Directory.Packages.props = Directory.Packages.props
-		global.json = global.json
 		LICENSE.md = LICENSE.md
 		README.md = README.md
 	EndProjectSection
@@ -23,6 +21,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GitHub", "GitHub", "{454C37
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Actions", "Actions", "{D435BA45-284A-49CB-B356-BC985CB2C696}"
 	ProjectSection(SolutionItems) = preProject
+		.github\workflows\build.yml = .github\workflows\build.yml
 		.github\workflows\release-drafter.yml = .github\workflows\release-drafter.yml
 		.github\workflows\update-labels.yml = .github\workflows\update-labels.yml
 	EndProjectSection

--- a/MetaBrainz.Common.Json/Converters/AnyObjectReader.cs
+++ b/MetaBrainz.Common.Json/Converters/AnyObjectReader.cs
@@ -162,14 +162,14 @@ public sealed class AnyObjectReader : JsonReader<object> {
           Type? elementType = null;
           var hasNulls = false;
           foreach (var element in elements) {
-            if (element == null) {
+            if (element is null) {
               hasNulls = true;
               continue;
             }
             var t = element.GetType();
             // ignore nullability
             t = Nullable.GetUnderlyingType(t) ?? t;
-            if (elementType == null) {
+            if (elementType is null) {
               elementType = t;
             }
             else if (elementType != t) {
@@ -177,7 +177,7 @@ public sealed class AnyObjectReader : JsonReader<object> {
               break;
             }
           }
-          if (elementType != null) {
+          if (elementType is not null) {
             if (elementType.IsValueType && hasNulls) {
               // make it nullable
               elementType = typeof(Nullable<>).MakeGenericType(elementType);

--- a/MetaBrainz.Common.Json/Converters/AnyObjectReader.cs
+++ b/MetaBrainz.Common.Json/Converters/AnyObjectReader.cs
@@ -108,21 +108,12 @@ public sealed class AnyObjectReader : JsonReader<object> {
           else {
             dec = null;
           }
-#if NETFRAMEWORK || NETSTANDARD2_0 // No IsFinite()
-          if (reader.TryGetDouble(out var floatVal) && !double.IsInfinity(floatVal) && !double.IsNaN(floatVal)) {
-            fp = floatVal;
-          }
-          else {
-            fp = null;
-          }
-#else
           if (reader.TryGetDouble(out var floatVal) && double.IsFinite(floatVal)) {
             fp = floatVal;
           }
           else {
             fp = null;
           }
-#endif
           if (!dec.HasValue && fp.HasValue) {
             // only double worked -> use it
             return fp;

--- a/MetaBrainz.Common.Json/Converters/ObjectWriter.cs
+++ b/MetaBrainz.Common.Json/Converters/ObjectWriter.cs
@@ -14,7 +14,8 @@ public abstract class ObjectWriter<T> : JsonWriter<T> {
   /// <param name="value">The value to write.</param>
   /// <param name="options">The options to use for serialization.</param>
   public sealed override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options) {
-    if (value == null) { // Will never be the case for normal JsonSerializer processing, but handle it anyway.
+    if (value is null) {
+      // Will never be the case for normal JsonSerializer processing, but handle it anyway.
       writer.WriteNullValue();
       return;
     }

--- a/MetaBrainz.Common.Json/JsonUtils.cs
+++ b/MetaBrainz.Common.Json/JsonUtils.cs
@@ -316,7 +316,7 @@ public static class JsonUtils {
   /// </returns>
   /// <typeparam name="T">The reference type to read.</typeparam>
   public static T? GetOptionalObject<T>(this ref Utf8JsonReader reader, JsonConverter<T> converter, JsonSerializerOptions options)
-    where T : class
+  where T : class
     => reader.TokenType == JsonTokenType.Null ? null : reader.GetObject(converter, options);
 
   /// <summary>Reads and converts JSON to an appropriate object, allowing null.</summary>
@@ -391,7 +391,7 @@ public static class JsonUtils {
   /// </returns>
   /// <typeparam name="T">The value type to read.</typeparam>
   public static T? GetOptionalValue<T>(this ref Utf8JsonReader reader, JsonConverter<T> converter, JsonSerializerOptions options)
-    where T : struct
+  where T : struct
     => reader.TokenType == JsonTokenType.Null ? null : converter.Read(ref reader, typeof(T), options);
 
   /// <summary>Gets the value for a property name node.</summary>
@@ -445,7 +445,7 @@ public static class JsonUtils {
   /// <returns>The value of type <typeparamref name="T"/> that was read.</returns>
   /// <typeparam name="T">The value type to read.</typeparam>
   public static T GetValue<T>(this ref Utf8JsonReader reader, JsonConverter<T> converter, JsonSerializerOptions options)
-    where T : struct
+  where T : struct
     => converter.Read(ref reader, typeof(T), options);
 
   /// <summary>Reads and converts JSON to a (read-only) dictionary.</summary>
@@ -469,7 +469,8 @@ public static class JsonUtils {
   /// <typeparam name="T">The value type for the dictionary.</typeparam>
   /// <typeparam name="TValue">The type to use when deserializing the dictionary values.</typeparam>
   public static IReadOnlyDictionary<string, T>? ReadDictionary<T, TValue>(this ref Utf8JsonReader reader,
-                                                                          JsonSerializerOptions options) where TValue : T {
+                                                                          JsonSerializerOptions options)
+  where TValue : T {
     if (reader.TokenType == JsonTokenType.Null) {
       return null;
     }
@@ -516,7 +517,8 @@ public static class JsonUtils {
   /// <typeparam name="TValue">The type to use when deserializing the dictionary values.</typeparam>
   public static IReadOnlyDictionary<string, T>? ReadDictionary<T, TValue>(this ref Utf8JsonReader reader,
                                                                           JsonConverter<TValue> converter,
-                                                                          JsonSerializerOptions options) where TValue : T {
+                                                                          JsonSerializerOptions options)
+  where TValue : T {
     if (reader.TokenType == JsonTokenType.Null) {
       return null;
     }
@@ -557,7 +559,7 @@ public static class JsonUtils {
   /// <typeparam name="T">The value type for the list.</typeparam>
   /// <typeparam name="TValue">The type to use when deserializing the list values.</typeparam>
   public static IReadOnlyList<T>? ReadList<T, TValue>(this ref Utf8JsonReader reader, JsonSerializerOptions options)
-    where TValue : T {
+  where TValue : T {
     if (reader.TokenType == JsonTokenType.Null) {
       return null;
     }
@@ -600,7 +602,8 @@ public static class JsonUtils {
   /// <typeparam name="T">The value type for the list.</typeparam>
   /// <typeparam name="TValue">The type to use when deserializing the list values.</typeparam>
   public static IReadOnlyList<T>? ReadList<T, TValue>(this ref Utf8JsonReader reader, JsonConverter<TValue> converter,
-                                                      JsonSerializerOptions options) where TValue : T {
+                                                      JsonSerializerOptions options)
+  where TValue : T {
     if (reader.TokenType == JsonTokenType.Null) {
       return null;
     }
@@ -660,7 +663,7 @@ public static class JsonUtils {
   /// <typeparam name="TConverter">The specific type used by the converter.</typeparam>
   public static void WriteList<TList, TConverter>(this Utf8JsonWriter writer, IEnumerable<TList> values,
                                                   JsonConverter<TConverter> converter, JsonSerializerOptions options)
-    where TList : TConverter {
+  where TList : TConverter {
     writer.WriteStartArray();
     foreach (var value in values) {
       converter.Write(writer, value, options);
@@ -693,7 +696,7 @@ public static class JsonUtils {
   /// <typeparam name="TConverter">The specific type used by the converter.</typeparam>
   public static async Task WriteListAsync<TList, TConverter>(this Utf8JsonWriter writer, IAsyncEnumerable<TList> values,
                                                              JsonConverter<TConverter> converter, JsonSerializerOptions options)
-    where TList : TConverter {
+  where TList : TConverter {
     writer.WriteStartArray();
     await foreach (var value in values) {
       converter.Write(writer, value, options);

--- a/MetaBrainz.Common.Json/MetaBrainz.Common.Json.csproj
+++ b/MetaBrainz.Common.Json/MetaBrainz.Common.Json.csproj
@@ -1,19 +1,26 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MetaBrainz.Build.Sdk">
+<Project>
+
+  <Sdk Name="MetaBrainz.Build.Sdk" Version="3.1.0" />
 
   <PropertyGroup>
+    <Authors>Zastai</Authors>
     <Title>Common JSON Utilities</Title>
     <Description>This package provides JSON-related utility classes used by other MetaBrainz packages.</Description>
-    <PackageCopyrightYears>2020, 2021, 2022</PackageCopyrightYears>
+    <PackageCopyrightOwners>Tim Van Holder</PackageCopyrightOwners>
+    <PackageCopyrightYears>2020, 2021, 2022, 2023</PackageCopyrightYears>
     <PackageRepositoryName>MetaBrainz.Common.Json</PackageRepositoryName>
     <PackageTags>MetaBrainz JSON</PackageTags>
-    <Version>5.1.1-pre</Version>
+    <Version>6.0.0-pre</Version>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <AssemblyIsComVisible>false</AssemblyIsComVisible>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" IncludeAssets="compile" PrivateAssets="all" />
     <PackageReference Include="MetaBrainz.Common" />
-    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
 </Project>

--- a/MetaBrainz.Common.Json/Properties/AssemblyInfo.cs
+++ b/MetaBrainz.Common.Json/Properties/AssemblyInfo.cs
@@ -1,3 +1,0 @@
-using System.Runtime.InteropServices;
-
-[assembly: ComVisible(false)]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
-# MetaBrainz.Common.Json [![Build Status](https://img.shields.io/appveyor/build/zastai/metabrainz-common-json)](https://ci.appveyor.com/project/Zastai/metabrainz-common-json) [![NuGet Version](https://img.shields.io/nuget/v/MetaBrainz.Common.Json)](https://www.nuget.org/packages/MetaBrainz.Common.Json)
+# MetaBrainz.Common.Json [![Build Status][CI-S]][CI-L] [![NuGet Package Version][NuGet-S]][NuGet-L]
 
 JSON-related helper classes, for use by the other `MetaBrainz.*` packages.
+
+[CI-S]: https://github.com/Zastai/MetaBrainz.Common.Json/actions/workflows/build.yml/badge.svg
+[CI-L]: https://github.com/Zastai/MetaBrainz.Common.Json/actions/workflows/build.yml
+
+[NuGet-S]: https://img.shields.io/nuget/v/MetaBrainz.Common.Json
+[NuGet-L]: https://www.nuget.org/packages/MetaBrainz.Common.Json

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,0 @@
-version: 'Build #{build}'
-image: Visual Studio 2022
-build_script:
-  - ps: .\build-package.ps1 -Configuration Debug
-after_build:
-  - ps: Get-ChildItem output/package/*/*.nupkg | % { appveyor PushArtifact $_ }

--- a/build-package.ps1
+++ b/build-package.ps1
@@ -3,6 +3,7 @@
 [CmdletBinding()]
 param (
   [string] $Configuration = 'Release',
+  [switch] $ContinuousIntegration = $false,
   [switch] $WithBinLog = $false
 )
 
@@ -41,7 +42,15 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 Write-Host "Building the solution (Configuration: $Configuration)..."
-dotnet build $opts --no-restore "-c:$Configuration" '-p:ContinuousIntegrationBuild=true' '-p:Deterministic=true'
+$props = @()
+if ($ContinuousIntegration) {
+  $props += '-p:ContinuousIntegrationBuild=true'
+  $props += '-p:Deterministic=true'
+}
+if ($Configuration -eq 'Debug') {
+  $props += '-p:DebugMessageImportance=high'
+}
+dotnet build $opts --no-restore "-c:$Configuration" $props
 Complete-BuildStep 'build'
 if ($LASTEXITCODE -ne 0) {
   Write-Error "SOLUTION BUILD FAILED"

--- a/global.json
+++ b/global.json
@@ -1,5 +1,0 @@
-{
-  "msbuild-sdks": {
-    "MetaBrainz.Build.Sdk" : "2.1.2"
-  }
-}

--- a/public-api/MetaBrainz.Common.Json.net6.0.cs.md
+++ b/public-api/MetaBrainz.Common.Json.net6.0.cs.md
@@ -1,0 +1,259 @@
+﻿# API Reference: MetaBrainz.Common.Json
+
+## Assembly Attributes
+
+```cs
+[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
+[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName = ".NET 6.0")]
+```
+
+## Namespace: MetaBrainz.Common.Json
+
+### Type: IJsonBasedObject
+
+```cs
+public interface IJsonBasedObject {
+
+  System.Collections.Generic.IReadOnlyDictionary<string, object?>? UnhandledProperties {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: JsonBasedObject
+
+```cs
+public abstract class JsonBasedObject : IJsonBasedObject {
+
+  System.Collections.Generic.Dictionary<string, object?>? UnhandledProperties {
+    public get;
+    public set;
+  }
+
+  protected JsonBasedObject();
+
+}
+```
+
+### Type: JsonUtils
+
+```cs
+public static class JsonUtils {
+
+  public static System.Text.Json.JsonSerializerOptions CreateReaderOptions();
+
+  public static System.Text.Json.JsonSerializerOptions CreateReaderOptions(System.Collections.Generic.IEnumerable<System.Text.Json.Serialization.JsonConverter> readers);
+
+  public static System.Text.Json.JsonSerializerOptions CreateReaderOptions(System.Collections.Generic.IEnumerable<System.Text.Json.Serialization.JsonConverter> readers, params System.Text.Json.Serialization.JsonConverter[] moreReaders);
+
+  public static System.Text.Json.JsonSerializerOptions CreateReaderOptions(params System.Text.Json.Serialization.JsonConverter[] readers);
+
+  public static System.Text.Json.JsonSerializerOptions CreateWriterOptions();
+
+  public static System.Text.Json.JsonSerializerOptions CreateWriterOptions(System.Collections.Generic.IEnumerable<System.Text.Json.Serialization.JsonConverter> writers);
+
+  public static System.Text.Json.JsonSerializerOptions CreateWriterOptions(System.Collections.Generic.IEnumerable<System.Text.Json.Serialization.JsonConverter> writers, params System.Text.Json.Serialization.JsonConverter[] moreWriters);
+
+  public static System.Text.Json.JsonSerializerOptions CreateWriterOptions(params System.Text.Json.Serialization.JsonConverter[] writers);
+
+  public static T? Deserialize<T>(string json, System.Text.Json.JsonSerializerOptions options);
+
+  public static T? Deserialize<T>(string json);
+
+  public static System.Threading.Tasks.ValueTask<T> DeserializeAsync<T>(System.IO.Stream json, System.Text.Json.JsonSerializerOptions options, System.Threading.CancellationToken cancellationToken = default);
+
+  public static System.Threading.Tasks.ValueTask<T> DeserializeAsync<T>(System.IO.Stream json, System.Threading.CancellationToken cancellationToken = default);
+
+  public static T GetJsonContent<T>(System.Net.Http.HttpResponseMessage response);
+
+  public static T GetJsonContent<T>(System.Net.Http.HttpResponseMessage response, System.Text.Json.JsonSerializerOptions options);
+
+  public static System.Threading.Tasks.Task<T> GetJsonContentAsync<T>(System.Net.Http.HttpResponseMessage response, System.Text.Json.JsonSerializerOptions options, System.Threading.CancellationToken cancellationToken = default);
+
+  public static System.Threading.Tasks.Task<T> GetJsonContentAsync<T>(System.Net.Http.HttpResponseMessage response, System.Threading.CancellationToken cancellationToken = default);
+
+  public static object GetObject(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.JsonSerializerOptions options);
+
+  public static T GetObject<T>(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.JsonSerializerOptions options);
+
+  public static T GetObject<T>(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.Serialization.JsonConverter<T> converter, System.Text.Json.JsonSerializerOptions options);
+
+  public static bool? GetOptionalBoolean(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static byte? GetOptionalByte(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static System.DateTimeOffset? GetOptionalDateTimeOffset(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static decimal? GetOptionalDecimal(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static double? GetOptionalDouble(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static System.Guid? GetOptionalGuid(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static short? GetOptionalInt16(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static int? GetOptionalInt32(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static long? GetOptionalInt64(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static object? GetOptionalObject(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.JsonSerializerOptions options);
+
+  public static T? GetOptionalObject<T>(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.JsonSerializerOptions options)
+    where T : class;
+
+  public static T? GetOptionalObject<T>(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.Serialization.JsonConverter<T> converter, System.Text.Json.JsonSerializerOptions options)
+    where T : class;
+
+  public static sbyte? GetOptionalSByte(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static float? GetOptionalSingle(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static ushort? GetOptionalUInt16(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static uint? GetOptionalUInt32(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static ulong? GetOptionalUInt64(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static System.Uri? GetOptionalUri(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static T? GetOptionalValue<T>(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.Serialization.JsonConverter<T> converter, System.Text.Json.JsonSerializerOptions options)
+    where T : struct;
+
+  public static string GetPropertyName(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static string GetRawStringValue(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static string GetStringValue(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static System.Uri GetUri(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static T GetValue<T>(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.Serialization.JsonConverter<T> converter, System.Text.Json.JsonSerializerOptions options)
+    where T : struct;
+
+  public static string Prettify(string json);
+
+  public static System.Collections.Generic.IReadOnlyDictionary<string, T>? ReadDictionary<T>(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.JsonSerializerOptions options);
+
+  public static System.Collections.Generic.IReadOnlyDictionary<string, T>? ReadDictionary<T>(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.Serialization.JsonConverter<T> converter, System.Text.Json.JsonSerializerOptions options);
+
+  public static System.Collections.Generic.IReadOnlyDictionary<string, T>? ReadDictionary<T, TValue>(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.JsonSerializerOptions options)
+    where TValue : T;
+
+  public static System.Collections.Generic.IReadOnlyDictionary<string, T>? ReadDictionary<T, TValue>(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.Serialization.JsonConverter<TValue> converter, System.Text.Json.JsonSerializerOptions options)
+    where TValue : T;
+
+  public static System.Collections.Generic.IReadOnlyList<T>? ReadList<T>(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.JsonSerializerOptions options);
+
+  public static System.Collections.Generic.IReadOnlyList<T>? ReadList<T>(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.Serialization.JsonConverter<T> converter, System.Text.Json.JsonSerializerOptions options);
+
+  public static System.Collections.Generic.IReadOnlyList<T>? ReadList<T, TValue>(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.JsonSerializerOptions options)
+    where TValue : T;
+
+  public static System.Collections.Generic.IReadOnlyList<T>? ReadList<T, TValue>(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.Serialization.JsonConverter<TValue> converter, System.Text.Json.JsonSerializerOptions options)
+    where TValue : T;
+
+  public static bool TryGetUri(this ref System.Text.Json.Utf8JsonReader reader, out System.Uri? value);
+
+  public static void WriteList<T>(this System.Text.Json.Utf8JsonWriter writer, System.Collections.Generic.IEnumerable<T> values, System.Text.Json.JsonSerializerOptions options);
+
+  public static void WriteList<TList, TConverter>(this System.Text.Json.Utf8JsonWriter writer, System.Collections.Generic.IEnumerable<TList> values, System.Text.Json.Serialization.JsonConverter<TConverter> converter, System.Text.Json.JsonSerializerOptions options)
+    where TList : TConverter;
+
+  public static System.Threading.Tasks.Task WriteListAsync<T>(this System.Text.Json.Utf8JsonWriter writer, System.Collections.Generic.IAsyncEnumerable<T> values, System.Text.Json.JsonSerializerOptions options);
+
+  public static System.Threading.Tasks.Task WriteListAsync<TList, TConverter>(this System.Text.Json.Utf8JsonWriter writer, System.Collections.Generic.IAsyncEnumerable<TList> values, System.Text.Json.Serialization.JsonConverter<TConverter> converter, System.Text.Json.JsonSerializerOptions options)
+    where TList : TConverter;
+
+}
+```
+
+## Namespace: MetaBrainz.Common.Json.Converters
+
+### Type: AnyObjectReader
+
+```cs
+public sealed class AnyObjectReader : JsonReader<object> {
+
+  public static readonly AnyObjectReader Instance;
+
+  public AnyObjectReader();
+
+  public override object Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options);
+
+}
+```
+
+### Type: JsonConverter\<T, TReader, TWriter>
+
+```cs
+public class JsonConverter<T, TReader, TWriter> : System.Text.Json.Serialization.JsonConverter<T>
+  where TReader : JsonReader<T>, new()
+  where TWriter : JsonWriter<T>, new() {
+
+  public JsonConverter();
+
+  public JsonConverter(TReader reader);
+
+  public JsonConverter(TReader reader, TWriter writer);
+
+  public JsonConverter(TWriter writer);
+
+  public override T? Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options);
+
+  public override void Write(System.Text.Json.Utf8JsonWriter writer, T value, System.Text.Json.JsonSerializerOptions options);
+
+}
+```
+
+### Type: JsonReader\<T>
+
+```cs
+public abstract class JsonReader<T> : System.Text.Json.Serialization.JsonConverter<T> {
+
+  protected JsonReader();
+
+  public sealed override void Write(System.Text.Json.Utf8JsonWriter writer, T value, System.Text.Json.JsonSerializerOptions options);
+
+}
+```
+
+### Type: JsonWriter\<T>
+
+```cs
+public abstract class JsonWriter<T> : System.Text.Json.Serialization.JsonConverter<T> {
+
+  protected JsonWriter();
+
+  public sealed override T Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options);
+
+}
+```
+
+### Type: ObjectReader\<T>
+
+```cs
+public abstract class ObjectReader<T> : JsonReader<T> {
+
+  protected ObjectReader();
+
+  public sealed override T Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options);
+
+  protected abstract T ReadObjectContents(ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.JsonSerializerOptions options);
+
+}
+```
+
+### Type: ObjectWriter\<T>
+
+```cs
+public abstract class ObjectWriter<T> : JsonWriter<T> {
+
+  protected ObjectWriter();
+
+  public sealed override void Write(System.Text.Json.Utf8JsonWriter writer, T value, System.Text.Json.JsonSerializerOptions options);
+
+  protected abstract void WriteObjectContents(System.Text.Json.Utf8JsonWriter writer, T value, System.Text.Json.JsonSerializerOptions options);
+
+}
+```

--- a/public-api/MetaBrainz.Common.Json.net8.0.cs.md
+++ b/public-api/MetaBrainz.Common.Json.net8.0.cs.md
@@ -1,0 +1,259 @@
+﻿# API Reference: MetaBrainz.Common.Json
+
+## Assembly Attributes
+
+```cs
+[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
+[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v8.0", FrameworkDisplayName = ".NET 8.0")]
+```
+
+## Namespace: MetaBrainz.Common.Json
+
+### Type: IJsonBasedObject
+
+```cs
+public interface IJsonBasedObject {
+
+  System.Collections.Generic.IReadOnlyDictionary<string, object?>? UnhandledProperties {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: JsonBasedObject
+
+```cs
+public abstract class JsonBasedObject : IJsonBasedObject {
+
+  System.Collections.Generic.Dictionary<string, object?>? UnhandledProperties {
+    public get;
+    public set;
+  }
+
+  protected JsonBasedObject();
+
+}
+```
+
+### Type: JsonUtils
+
+```cs
+public static class JsonUtils {
+
+  public static System.Text.Json.JsonSerializerOptions CreateReaderOptions();
+
+  public static System.Text.Json.JsonSerializerOptions CreateReaderOptions(System.Collections.Generic.IEnumerable<System.Text.Json.Serialization.JsonConverter> readers);
+
+  public static System.Text.Json.JsonSerializerOptions CreateReaderOptions(System.Collections.Generic.IEnumerable<System.Text.Json.Serialization.JsonConverter> readers, params System.Text.Json.Serialization.JsonConverter[] moreReaders);
+
+  public static System.Text.Json.JsonSerializerOptions CreateReaderOptions(params System.Text.Json.Serialization.JsonConverter[] readers);
+
+  public static System.Text.Json.JsonSerializerOptions CreateWriterOptions();
+
+  public static System.Text.Json.JsonSerializerOptions CreateWriterOptions(System.Collections.Generic.IEnumerable<System.Text.Json.Serialization.JsonConverter> writers);
+
+  public static System.Text.Json.JsonSerializerOptions CreateWriterOptions(System.Collections.Generic.IEnumerable<System.Text.Json.Serialization.JsonConverter> writers, params System.Text.Json.Serialization.JsonConverter[] moreWriters);
+
+  public static System.Text.Json.JsonSerializerOptions CreateWriterOptions(params System.Text.Json.Serialization.JsonConverter[] writers);
+
+  public static T? Deserialize<T>(string json, System.Text.Json.JsonSerializerOptions options);
+
+  public static T? Deserialize<T>(string json);
+
+  public static System.Threading.Tasks.ValueTask<T> DeserializeAsync<T>(System.IO.Stream json, System.Text.Json.JsonSerializerOptions options, System.Threading.CancellationToken cancellationToken = default);
+
+  public static System.Threading.Tasks.ValueTask<T> DeserializeAsync<T>(System.IO.Stream json, System.Threading.CancellationToken cancellationToken = default);
+
+  public static T GetJsonContent<T>(System.Net.Http.HttpResponseMessage response);
+
+  public static T GetJsonContent<T>(System.Net.Http.HttpResponseMessage response, System.Text.Json.JsonSerializerOptions options);
+
+  public static System.Threading.Tasks.Task<T> GetJsonContentAsync<T>(System.Net.Http.HttpResponseMessage response, System.Text.Json.JsonSerializerOptions options, System.Threading.CancellationToken cancellationToken = default);
+
+  public static System.Threading.Tasks.Task<T> GetJsonContentAsync<T>(System.Net.Http.HttpResponseMessage response, System.Threading.CancellationToken cancellationToken = default);
+
+  public static object GetObject(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.JsonSerializerOptions options);
+
+  public static T GetObject<T>(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.JsonSerializerOptions options);
+
+  public static T GetObject<T>(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.Serialization.JsonConverter<T> converter, System.Text.Json.JsonSerializerOptions options);
+
+  public static bool? GetOptionalBoolean(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static byte? GetOptionalByte(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static System.DateTimeOffset? GetOptionalDateTimeOffset(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static decimal? GetOptionalDecimal(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static double? GetOptionalDouble(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static System.Guid? GetOptionalGuid(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static short? GetOptionalInt16(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static int? GetOptionalInt32(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static long? GetOptionalInt64(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static object? GetOptionalObject(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.JsonSerializerOptions options);
+
+  public static T? GetOptionalObject<T>(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.JsonSerializerOptions options)
+    where T : class;
+
+  public static T? GetOptionalObject<T>(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.Serialization.JsonConverter<T> converter, System.Text.Json.JsonSerializerOptions options)
+    where T : class;
+
+  public static sbyte? GetOptionalSByte(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static float? GetOptionalSingle(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static ushort? GetOptionalUInt16(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static uint? GetOptionalUInt32(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static ulong? GetOptionalUInt64(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static System.Uri? GetOptionalUri(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static T? GetOptionalValue<T>(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.Serialization.JsonConverter<T> converter, System.Text.Json.JsonSerializerOptions options)
+    where T : struct;
+
+  public static string GetPropertyName(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static string GetRawStringValue(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static string GetStringValue(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static System.Uri GetUri(this ref System.Text.Json.Utf8JsonReader reader);
+
+  public static T GetValue<T>(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.Serialization.JsonConverter<T> converter, System.Text.Json.JsonSerializerOptions options)
+    where T : struct;
+
+  public static string Prettify(string json);
+
+  public static System.Collections.Generic.IReadOnlyDictionary<string, T>? ReadDictionary<T>(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.JsonSerializerOptions options);
+
+  public static System.Collections.Generic.IReadOnlyDictionary<string, T>? ReadDictionary<T>(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.Serialization.JsonConverter<T> converter, System.Text.Json.JsonSerializerOptions options);
+
+  public static System.Collections.Generic.IReadOnlyDictionary<string, T>? ReadDictionary<T, TValue>(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.JsonSerializerOptions options)
+    where TValue : T;
+
+  public static System.Collections.Generic.IReadOnlyDictionary<string, T>? ReadDictionary<T, TValue>(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.Serialization.JsonConverter<TValue> converter, System.Text.Json.JsonSerializerOptions options)
+    where TValue : T;
+
+  public static System.Collections.Generic.IReadOnlyList<T>? ReadList<T>(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.JsonSerializerOptions options);
+
+  public static System.Collections.Generic.IReadOnlyList<T>? ReadList<T>(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.Serialization.JsonConverter<T> converter, System.Text.Json.JsonSerializerOptions options);
+
+  public static System.Collections.Generic.IReadOnlyList<T>? ReadList<T, TValue>(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.JsonSerializerOptions options)
+    where TValue : T;
+
+  public static System.Collections.Generic.IReadOnlyList<T>? ReadList<T, TValue>(this ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.Serialization.JsonConverter<TValue> converter, System.Text.Json.JsonSerializerOptions options)
+    where TValue : T;
+
+  public static bool TryGetUri(this ref System.Text.Json.Utf8JsonReader reader, out System.Uri? value);
+
+  public static void WriteList<T>(this System.Text.Json.Utf8JsonWriter writer, System.Collections.Generic.IEnumerable<T> values, System.Text.Json.JsonSerializerOptions options);
+
+  public static void WriteList<TList, TConverter>(this System.Text.Json.Utf8JsonWriter writer, System.Collections.Generic.IEnumerable<TList> values, System.Text.Json.Serialization.JsonConverter<TConverter> converter, System.Text.Json.JsonSerializerOptions options)
+    where TList : TConverter;
+
+  public static System.Threading.Tasks.Task WriteListAsync<T>(this System.Text.Json.Utf8JsonWriter writer, System.Collections.Generic.IAsyncEnumerable<T> values, System.Text.Json.JsonSerializerOptions options);
+
+  public static System.Threading.Tasks.Task WriteListAsync<TList, TConverter>(this System.Text.Json.Utf8JsonWriter writer, System.Collections.Generic.IAsyncEnumerable<TList> values, System.Text.Json.Serialization.JsonConverter<TConverter> converter, System.Text.Json.JsonSerializerOptions options)
+    where TList : TConverter;
+
+}
+```
+
+## Namespace: MetaBrainz.Common.Json.Converters
+
+### Type: AnyObjectReader
+
+```cs
+public sealed class AnyObjectReader : JsonReader<object> {
+
+  public static readonly AnyObjectReader Instance;
+
+  public AnyObjectReader();
+
+  public override object Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options);
+
+}
+```
+
+### Type: JsonConverter\<T, TReader, TWriter>
+
+```cs
+public class JsonConverter<T, TReader, TWriter> : System.Text.Json.Serialization.JsonConverter<T>
+  where TReader : JsonReader<T>, new()
+  where TWriter : JsonWriter<T>, new() {
+
+  public JsonConverter();
+
+  public JsonConverter(TReader reader);
+
+  public JsonConverter(TReader reader, TWriter writer);
+
+  public JsonConverter(TWriter writer);
+
+  public override T? Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options);
+
+  public override void Write(System.Text.Json.Utf8JsonWriter writer, T value, System.Text.Json.JsonSerializerOptions options);
+
+}
+```
+
+### Type: JsonReader\<T>
+
+```cs
+public abstract class JsonReader<T> : System.Text.Json.Serialization.JsonConverter<T> {
+
+  protected JsonReader();
+
+  public sealed override void Write(System.Text.Json.Utf8JsonWriter writer, T value, System.Text.Json.JsonSerializerOptions options);
+
+}
+```
+
+### Type: JsonWriter\<T>
+
+```cs
+public abstract class JsonWriter<T> : System.Text.Json.Serialization.JsonConverter<T> {
+
+  protected JsonWriter();
+
+  public sealed override T Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options);
+
+}
+```
+
+### Type: ObjectReader\<T>
+
+```cs
+public abstract class ObjectReader<T> : JsonReader<T> {
+
+  protected ObjectReader();
+
+  public sealed override T Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options);
+
+  protected abstract T ReadObjectContents(ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.JsonSerializerOptions options);
+
+}
+```
+
+### Type: ObjectWriter\<T>
+
+```cs
+public abstract class ObjectWriter<T> : JsonWriter<T> {
+
+  protected ObjectWriter();
+
+  public sealed override void Write(System.Text.Json.Utf8JsonWriter writer, T value, System.Text.Json.JsonSerializerOptions options);
+
+  protected abstract void WriteObjectContents(System.Text.Json.Utf8JsonWriter writer, T value, System.Text.Json.JsonSerializerOptions options);
+
+}
+```


### PR DESCRIPTION
- update GitHub Actions
- drop AppVeyor builds
  - instead, use GitHub Actions for CI
- enable Dependabot for GitHub Actions and configure labels for it
- set `AssemblyIsComVisible` to `false` in the project file
  - allows dropping the `AssemblyInfo.cs` file
- add "public API" reference files
- align copyright years between license file and project
- target `net6.0` and `net8.0` only
  - allows cleaning up some compatibility code for .NET Framework/Standard/Core
  - bump version to 6.0.0-pre