### PR TITLE
Drop conditional compilation for debugging

### DIFF
--- a/public-api/MetaBrainz.Common.Json.net6.0.cs.md
+++ b/public-api/MetaBrainz.Common.Json.net6.0.cs.md
@@ -41,6 +41,21 @@ public abstract class JsonBasedObject : IJsonBasedObject {
 ```cs
 public static class JsonUtils {
 
+  System.Action<System.Net.Http.Headers.HttpContentHeaders>? ShowReceivedHeaders {
+    public static get;
+    public static set;
+  }
+
+  System.Action<string>? ShowReceivedJson {
+    public static get;
+    public static set;
+  }
+
+  bool WriteIndentedByDefault {
+    public static get;
+    public static set;
+  }
+
   public static System.Text.Json.JsonSerializerOptions CreateReaderOptions();
 
   public static System.Text.Json.JsonSerializerOptions CreateReaderOptions(System.Collections.Generic.IEnumerable<System.Text.Json.Serialization.JsonConverter> readers);

--- a/public-api/MetaBrainz.Common.Json.net8.0.cs.md
+++ b/public-api/MetaBrainz.Common.Json.net8.0.cs.md
@@ -41,6 +41,21 @@ public abstract class JsonBasedObject : IJsonBasedObject {
 ```cs
 public static class JsonUtils {
 
+  System.Action<System.Net.Http.Headers.HttpContentHeaders>? ShowReceivedHeaders {
+    public static get;
+    public static set;
+  }
+
+  System.Action<string>? ShowReceivedJson {
+    public static get;
+    public static set;
+  }
+
+  bool WriteIndentedByDefault {
+    public static get;
+    public static set;
+  }
+
   public static System.Text.Json.JsonSerializerOptions CreateReaderOptions();
 
   public static System.Text.Json.JsonSerializerOptions CreateReaderOptions(System.Collections.Generic.IEnumerable<System.Text.Json.Serialization.JsonConverter> readers);


### PR DESCRIPTION
This replaces conditional compilation that enabled some things only in debug mode with configurable behaviour.

New properties on `JsonUtils`:
- `ShowReceivedHeaders`
  - allows getting at the headers of a received JSON response
- `ShowReceivedJson`
  - allows getting at the content of a received JSON response
- `WriteIndentedByDefault`
  - affects whether JSON options created by `CreateWriterOptions` default to producing indented JSON