### PR TITLE
Update `MetaBrainz.Build.Sdk` to v3.1.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,13 +34,13 @@ jobs:
     - name: Run build script (${{matrix.configuration}})
       run: pwsh ./build-package.ps1 -ContinuousIntegration -WithBinLog -Configuration ${{matrix.configuration}}
     - name: "Artifact: MSBuild Logs"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: MSBuild Logs (${{matrix.configuration}})
         path: msbuild.*.binlog
     - name: "Artifact: NuGet Packages"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: NuGet Packages (${{matrix.configuration}})
         path: "output/package/${{matrix.configuration}}/*.*nupkg"

--- a/MetaBrainz.Common.Json/MetaBrainz.Common.Json.csproj
+++ b/MetaBrainz.Common.Json/MetaBrainz.Common.Json.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
 
-  <Sdk Name="MetaBrainz.Build.Sdk" Version="3.1.0" />
+  <Sdk Name="MetaBrainz.Build.Sdk" Version="3.1.1" />
 
   <PropertyGroup>
     <Authors>Zastai</Authors>


### PR DESCRIPTION
This refreshes the package icon used by this package.

It also bumps up the GitHub `upload-artifact` action to v4.