### PR TITLE
Bump `MetaBrainz.Common` to version 4.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   <!-- Package Versions -->
   <ItemGroup>
     <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0" />
-    <PackageVersion Include="MetaBrainz.Common" Version="3.0.0" />
+    <PackageVersion Include="MetaBrainz.Common" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/MetaBrainz.Common.Json/JsonUtils.cs
+++ b/MetaBrainz.Common.Json/JsonUtils.cs
@@ -29,20 +29,6 @@ public static class JsonUtils {
   /// <typeparam name="T">The type of object to deserialize.</typeparam>
   /// <returns>A newly deserialized object of type <typeparamref name="T"/>.</returns>
   /// <remarks>The options used match those returned by <see cref="CreateReaderOptions()"/>.</remarks>
-  public static T? Deserialize<T>(Stream json) => JsonUtils.Deserialize<T>(json, JsonUtils.ReaderOptions);
-
-  /// <summary>Deserializes JSON to an object of the specified type.</summary>
-  /// <param name="json">The JSON to deserialize.</param>
-  /// <param name="options">The options to use for deserialization.</param>
-  /// <typeparam name="T">The type of object to deserialize.</typeparam>
-  /// <returns>A newly deserialized object of type <typeparamref name="T"/>.</returns>
-  public static T? Deserialize<T>(Stream json, JsonSerializerOptions options) => JsonSerializer.Deserialize<T>(json, options);
-
-  /// <summary>Deserializes JSON to an object of the specified type, using default options.</summary>
-  /// <param name="json">The JSON to deserialize.</param>
-  /// <typeparam name="T">The type of object to deserialize.</typeparam>
-  /// <returns>A newly deserialized object of type <typeparamref name="T"/>.</returns>
-  /// <remarks>The options used match those returned by <see cref="CreateReaderOptions()"/>.</remarks>
   public static T? Deserialize<T>(string json) => JsonUtils.Deserialize<T>(json, JsonUtils.ReaderOptions);
 
   /// <summary>Deserializes JSON to an object of the specified type.</summary>
@@ -70,28 +56,6 @@ public static class JsonUtils {
   public static ValueTask<T?> DeserializeAsync<T>(Stream json, JsonSerializerOptions options,
                                                   CancellationToken cancellationToken = default)
     => JsonSerializer.DeserializeAsync<T>(json, options, cancellationToken);
-
-  /// <summary>Deserializes an object from the JSON content of an HTTP response.</summary>
-  /// <param name="response">The response to process.</param>
-  /// <typeparam name="T">The specific type to deserialize.</typeparam>
-  /// <returns>The deserialized object.</returns>
-  /// <exception cref="JsonException">
-  /// When an object of type <typeparamref name="T"/> could not be deserialized from the contents of <paramref name="response"/>.
-  /// </exception>
-  /// <remarks>The options used match those returned by <see cref="CreateReaderOptions()"/>.</remarks>
-  public static T GetJsonContent<T>(HttpResponseMessage response)
-    => AsyncUtils.ResultOf(JsonUtils.GetJsonContentAsync<T>(response));
-
-  /// <summary>Deserializes an object from the JSON content of an HTTP response.</summary>
-  /// <param name="response">The response to process.</param>
-  /// <param name="options">The JSON serializer options to apply.</param>
-  /// <typeparam name="T">The specific type to deserialize.</typeparam>
-  /// <returns>The deserialized object.</returns>
-  /// <exception cref="JsonException">
-  /// When an object of type <typeparamref name="T"/> could not be deserialized from the contents of <paramref name="response"/>.
-  /// </exception>
-  public static T GetJsonContent<T>(HttpResponseMessage response, JsonSerializerOptions options)
-    => AsyncUtils.ResultOf(JsonUtils.GetJsonContentAsync<T>(response, options));
 
   /// <summary>Deserializes an object from the JSON content of an HTTP response.</summary>
   /// <param name="response">The response to process.</param>

--- a/MetaBrainz.Common.Json/MetaBrainz.Common.Json.csproj
+++ b/MetaBrainz.Common.Json/MetaBrainz.Common.Json.csproj
@@ -11,7 +11,7 @@
     <PackageCopyrightYears>2020, 2021, 2022, 2023, 2025</PackageCopyrightYears>
     <PackageRepositoryName>MetaBrainz.Common.Json</PackageRepositoryName>
     <PackageTags>MetaBrainz JSON</PackageTags>
-    <Version>6.0.3-pre</Version>
+    <Version>7.0.0-pre</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This drops all non-`async` versions of `async` methods (i.e. `JsonUtils.Deserialize<T>()` and `JsonUtils.GetJsonContent<T>()`).

Note that the version of `JsonUtils.Deserialize<T>()` taking a `string` remains; it has no `async` version.