### PR TITLE
Add `OptionalObjectReader`

### DIFF
--- a/MetaBrainz.Common.Json/Converters/OptionalObjectReader.cs
+++ b/MetaBrainz.Common.Json/Converters/OptionalObjectReader.cs
@@ -6,13 +6,15 @@ using JetBrains.Annotations;
 
 namespace MetaBrainz.Common.Json.Converters;
 
-/// <summary>A JSON reader that handles fields of type <see cref="object"/> using the most appropriate framework type.</summary>
+/// <summary>
+/// A JSON reader that handles nullable fields of type <see cref="object"/> using the most appropriate framework type.
+/// </summary>
 [PublicAPI]
-public sealed class AnyObjectReader : JsonReader<object> {
+public sealed class OptionalObjectReader : JsonReader<object?> {
 
   /// <summary>A global instance, for easy use without unnecessary object allocation.</summary>
   /// <remarks>This reader is stateless, so this single instance can be used everywhere.</remarks>
-  public static readonly AnyObjectReader Instance = new();
+  public static readonly OptionalObjectReader Instance = new();
 
   /// <summary>Reads and converts JSON to the most appropriate .NET framework type.</summary>
   /// <param name="reader">The reader to read from.</param>
@@ -36,7 +38,7 @@ public sealed class AnyObjectReader : JsonReader<object> {
   ///       <see cref="object"/> (<see langword="null"/>).<br/>
   ///       Note: only when <see langword="null"/> is allowed via <paramref name="allowNullInArrays"/> or
   ///       <paramref name="allowNullAsPropertyValue"/>.<br/>
-  ///       The top-level value is never allowed to be <see langword="null"/>; to allow that, use <see cref="OptionalObjectReader"/>
+  ///       The top-level value is always allowed to be <see langword="null"/>; to disallow that, use <see cref="AnyObjectReader"/>
   ///       instead.
   ///     </description>
   ///   </item>
@@ -93,149 +95,11 @@ public sealed class AnyObjectReader : JsonReader<object> {
   ///   preserved more digits. The degenerate case (where the decimal would be 0) is detected, but in other cases the less precise
   ///   decimal will be used.
   /// </remarks>
-  public static object Read(ref Utf8JsonReader reader, JsonSerializerOptions options, bool allowNullInArrays = true,
-                            bool allowNullAsPropertyValue = true) {
-    switch (reader.TokenType) {
-      // Easy cases
-      case JsonTokenType.False:
-        return false;
-      case JsonTokenType.True:
-        return true;
-      // Cases requiring further deduction
-      case JsonTokenType.Number: {
-        if (reader.TryGetInt32(out var i32)) {
-          return i32;
-        }
-        if (reader.TryGetInt64(out var i64)) {
-          return i64;
-        }
-        if (reader.TryGetUInt64(out var ui64)) {
-          return ui64;
-        }
-        {
-          decimal? dec;
-          double? fp;
-          if (reader.TryGetDecimal(out var decVal)) {
-            dec = decVal;
-          }
-          else {
-            dec = null;
-          }
-          if (reader.TryGetDouble(out var floatVal) && double.IsFinite(floatVal)) {
-            fp = floatVal;
-          }
-          else {
-            fp = null;
-          }
-          if (!dec.HasValue && fp.HasValue) {
-            // only double worked -> use it
-            return fp;
-          }
-          if (dec.HasValue && fp.HasValue) {
-            // check for a degenerate case: 1E-29 converts successfully to 0.0000000000000000000000000000m
-            // FIXME: 12E-29 converts to 0.0000000000000000000000000001m and 1.2E-28; ideally, we'd pick the double then too
-            if (dec.Value == 0 && Math.Abs(fp.Value) > double.Epsilon) {
-              return fp;
-            }
-            // otherwise, assume the decimal will be better
-            return dec;
-          }
-          // else: if converted to decimal but not double: should be impossible, so probably bad conversion: use fallback
-          // else: if neither decimal nor double: use fallback
-        }
-        return reader.GetRawStringValue();
-      }
-      case JsonTokenType.String: {
-        // Note: NOT TryGetBytesFromBase64() because that has many false positives (e.g. most ISRC values).
-        if (reader.TryGetDateTimeOffset(out var dto)) {
-          return dto;
-        }
-        if (reader.TryGetGuid(out var guid)) {
-          return guid;
-        }
-        var text = reader.GetStringValue();
-        if (Uri.TryCreate(text, UriKind.Absolute, out var uri)) {
-          return uri;
-        }
-        // FIXME: Are the other "special" strings we should recognize?
-        return text;
-      }
-      case JsonTokenType.StartArray: {
-        reader.Read();
-        if (reader.TokenType == JsonTokenType.EndArray) {
-          return Array.Empty<object?>();
-        }
-        var elements = new List<object?>();
-        while (reader.TokenType != JsonTokenType.EndArray) {
-          var element = reader.TokenType switch {
-            JsonTokenType.Null when allowNullInArrays => null,
-            _ => AnyObjectReader.Read(ref reader, options, allowNullInArrays, allowNullAsPropertyValue)
-          };
-          elements.Add(element);
-          reader.Read();
-        }
-        try {
-          // if all elements are the same type (or null), try to map it to an array of that type
-          Type? elementType = null;
-          var hasNulls = false;
-          foreach (var element in elements) {
-            if (element is null) {
-              hasNulls = true;
-              continue;
-            }
-            var t = element.GetType();
-            // ignore nullability
-            t = Nullable.GetUnderlyingType(t) ?? t;
-            if (elementType is null) {
-              elementType = t;
-            }
-            else if (elementType != t) {
-              elementType = null;
-              break;
-            }
-          }
-          if (elementType is not null) {
-            if (elementType.IsValueType && hasNulls) {
-              // make it nullable
-              elementType = typeof(Nullable<>).MakeGenericType(elementType);
-            }
-            var len = elements.Count;
-            var typedArray = Array.CreateInstance(elementType, len);
-            for (var i = 0; i < len; ++i) {
-              typedArray.SetValue(Convert.ChangeType(elements[i], elementType), i);
-            }
-            return typedArray;
-          }
-        }
-        catch {
-          // No worries, we still have the basic object array to return
-        }
-        return elements.ToArray();
-      }
-      case JsonTokenType.StartObject: {
-        reader.Read();
-        var obj = new Dictionary<string, object?>();
-        while (reader.TokenType != JsonTokenType.EndObject) {
-          if (reader.TokenType != JsonTokenType.PropertyName) {
-            throw new JsonException($"Expected a JSON object property, but received a {reader.TokenType} token instead.");
-          }
-          var prop = reader.GetPropertyName();
-          if (obj.ContainsKey(prop)) {
-            throw new JsonException($"Encountered a duplicate JSON object property ('{prop}').");
-          }
-          reader.Read();
-          obj[prop] = reader.TokenType switch {
-            JsonTokenType.Null when allowNullAsPropertyValue => null,
-            _ => AnyObjectReader.Read(ref reader, options, allowNullInArrays, allowNullAsPropertyValue)
-          };
-          reader.Read();
-        }
-        return obj;
-      }
-      default:
-        throw new JsonException($"Token ({reader.TokenType}: {reader.GetRawStringValue()}) cannot be converted to an object.");
-    }
-  }
+  public static object? Read(ref Utf8JsonReader reader, JsonSerializerOptions options, bool allowNullInArrays = true,
+                             bool allowNullAsPropertyValue = true) => reader.TokenType switch {
+    JsonTokenType.Null => null,
+    _ => AnyObjectReader.Read(ref reader, options, allowNullInArrays, allowNullAsPropertyValue)
+  };
 
   /// <summary>Reads and converts JSON to the most appropriate .NET framework type.</summary>
   /// <param name="reader">The reader to read from.</param>
@@ -253,7 +117,7 @@ public sealed class AnyObjectReader : JsonReader<object> {
   ///     <description>
   ///       <see cref="object"/> (<see langword="null"/>).<br/>
   ///       Note: only for elements in nested arrays and nested property values.<br/>
-  ///       The top-level value is never allowed to be <see langword="null"/>; to allow that, use <see cref="OptionalObjectReader"/>
+  ///       The top-level value is always allowed to be <see langword="null"/>; to disallow that, use <see cref="AnyObjectReader"/>
   ///       instead.
   ///     </description>
   ///   </item>
@@ -310,7 +174,7 @@ public sealed class AnyObjectReader : JsonReader<object> {
   ///   preserved more digits. The degenerate case (where the decimal would be 0) is detected, but in other cases the less precise
   ///   decimal will be used.
   /// </remarks>
-  public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-    => AnyObjectReader.Read(ref reader, options);
+  public override object? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    => OptionalObjectReader.Read(ref reader, options);
 
 }

--- a/MetaBrainz.Common.Json/MetaBrainz.Common.Json.csproj
+++ b/MetaBrainz.Common.Json/MetaBrainz.Common.Json.csproj
@@ -11,7 +11,7 @@
     <PackageCopyrightYears>2020, 2021, 2022, 2023, 2025</PackageCopyrightYears>
     <PackageRepositoryName>MetaBrainz.Common.Json</PackageRepositoryName>
     <PackageTags>MetaBrainz JSON</PackageTags>
-    <Version>7.0.1-pre</Version>
+    <Version>7.1.0-pre</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/public-api/MetaBrainz.Common.Json.net8.0.cs.md
+++ b/public-api/MetaBrainz.Common.Json.net8.0.cs.md
@@ -182,6 +182,8 @@ public sealed class AnyObjectReader : JsonReader<object> {
 
   public AnyObjectReader();
 
+  public static object PerformRead(ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.JsonSerializerOptions options, bool allowNullInArrays, bool allowNullAsPropertyValue);
+
   public override object Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options);
 
 }
@@ -257,6 +259,22 @@ public abstract class ObjectWriter<T> : JsonWriter<T> {
   public sealed override void Write(System.Text.Json.Utf8JsonWriter writer, T value, System.Text.Json.JsonSerializerOptions options);
 
   protected abstract void WriteObjectContents(System.Text.Json.Utf8JsonWriter writer, T value, System.Text.Json.JsonSerializerOptions options);
+
+}
+```
+
+### Type: OptionalObjectReader
+
+```cs
+public sealed class OptionalObjectReader : JsonReader<object?> {
+
+  public static readonly OptionalObjectReader Instance;
+
+  public OptionalObjectReader();
+
+  public static object? PerformRead(ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.JsonSerializerOptions options, bool allowNullInArrays, bool allowNullAsPropertyValue);
+
+  public override object? Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options);
 
 }
 ```


### PR DESCRIPTION
This is essentially identical to `AnyObjectReader`, except that it allows the top level object to be `null` as well.

The documentation for `AnyObjectReader.Read()` now makes it clear that while elements of nested lists and dictionaries are allowed to be `null`, the top level item is not.

Both `AnyObjectReader` and `OptionalObjectReader` now also expose their functionality as a static `Read()` method, which takes two boolean flags (`allowNullInArrays` and `allowNullAsPropertyValue`, both defaulting to `true`), giving more control over where `null` is allowed. The instance method just calls through to this new static one to retain the current behaviour.

The version number is bumped to 7.1.0-pre due to the new API.